### PR TITLE
Add users module with admin and profile controllers

### DIFF
--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -1,12 +1,15 @@
 import { Module } from '@nestjs/common';
 import { JwtModule } from '@nestjs/jwt';
 import { PassportModule } from '@nestjs/passport';
+import { ConfigModule } from '@nestjs/config';
 import { UsersModule } from '../users/users.module';
 import { AuthService } from './auth.service';
 import { AuthController } from './auth.controller';
+import { JwtStrategy } from './jwt.strategy';
 
 @Module({
   imports: [
+    ConfigModule,
     UsersModule,
     PassportModule,
     JwtModule.register({
@@ -15,6 +18,7 @@ import { AuthController } from './auth.controller';
     }),
   ],
   controllers: [AuthController],
-  providers: [AuthService],
+  providers: [AuthService, JwtStrategy],
+  exports: [JwtModule],
 })
 export class AuthModule {}

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -30,7 +30,7 @@ export class AuthService {
     if (!user) {
       throw new UnauthorizedException();
     }
-    const payload = { sub: user.id, email: user.email };
+    const payload = { sub: user.id, email: user.email, role: user.role };
     return {
       access_token: await this.jwtService.signAsync(payload),
     };

--- a/src/auth/jwt-auth.guard.ts
+++ b/src/auth/jwt-auth.guard.ts
@@ -1,0 +1,5 @@
+import { Injectable } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+
+@Injectable()
+export class JwtAuthGuard extends AuthGuard('jwt') {}

--- a/src/auth/jwt.strategy.ts
+++ b/src/auth/jwt.strategy.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { PassportStrategy } from '@nestjs/passport';
+import { ExtractJwt, Strategy } from 'passport-jwt';
+
+@Injectable()
+export class JwtStrategy extends PassportStrategy(Strategy) {
+  constructor(configService: ConfigService) {
+    super({
+      jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+      ignoreExpiration: false,
+      secretOrKey: configService.get('JWT_SECRET') || 'secret',
+    });
+  }
+
+  async validate(payload: any) {
+    return { id: payload.sub, email: payload.email, role: payload.role };
+  }
+}

--- a/src/auth/roles.decorator.ts
+++ b/src/auth/roles.decorator.ts
@@ -1,0 +1,3 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const Roles = (...roles: string[]) => SetMetadata('roles', roles);

--- a/src/auth/roles.guard.ts
+++ b/src/auth/roles.guard.ts
@@ -1,0 +1,19 @@
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+
+@Injectable()
+export class RolesGuard implements CanActivate {
+  constructor(private reflector: Reflector) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const requiredRoles = this.reflector.getAllAndOverride<string[]>('roles', [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+    if (!requiredRoles) {
+      return true;
+    }
+    const { user } = context.switchToHttp().getRequest();
+    return requiredRoles.includes(user?.role);
+  }
+}

--- a/src/users/controllers/admin-users.controller.ts
+++ b/src/users/controllers/admin-users.controller.ts
@@ -1,0 +1,35 @@
+import { Controller, Delete, Get, Param, Put, Query, Body, UseGuards } from '@nestjs/common';
+import { UsersService } from '../users.service';
+import { JwtAuthGuard } from '../../auth/jwt-auth.guard';
+import { RolesGuard } from '../../auth/roles.guard';
+import { Roles } from '../../auth/roles.decorator';
+import { QueryUsersDto } from '../dto/query-users.dto';
+import { UpdateStatusDto } from '../dto/update-status.dto';
+import { UpdateRoleDto } from '../dto/update-role.dto';
+
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles('admin')
+@Controller('api/admin/users')
+export class AdminUsersController {
+  constructor(private readonly usersService: UsersService) {}
+
+  @Get()
+  findAll(@Query() query: QueryUsersDto) {
+    return this.usersService.findAll(query);
+  }
+
+  @Put(':id/status')
+  updateStatus(@Param('id') id: string, @Body() dto: UpdateStatusDto) {
+    return this.usersService.updateStatus(Number(id), dto);
+  }
+
+  @Put(':id/role')
+  updateRole(@Param('id') id: string, @Body() dto: UpdateRoleDto) {
+    return this.usersService.updateRole(Number(id), dto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.usersService.remove(Number(id));
+  }
+}

--- a/src/users/controllers/profile.controller.ts
+++ b/src/users/controllers/profile.controller.ts
@@ -1,0 +1,24 @@
+import { Controller, Get, Put, Body, UseGuards, Req } from '@nestjs/common';
+import { Request } from 'express';
+import { UsersService } from '../users.service';
+import { JwtAuthGuard } from '../../auth/jwt-auth.guard';
+import { UpdateProfileDto } from '../dto/update-profile.dto';
+
+@UseGuards(JwtAuthGuard)
+@Controller('api/profile')
+export class ProfileController {
+  constructor(private readonly usersService: UsersService) {}
+
+  @Get()
+  async getProfile(@Req() req: Request) {
+    const user = await this.usersService.findById(req.user['id']);
+    if (!user) return null;
+    const { id, name, email, isProfessional, professionalType, avatar, phone } = user;
+    return { id, name, email, isProfessional, professionalType, avatar, phone };
+  }
+
+  @Put()
+  updateProfile(@Req() req: Request, @Body() dto: UpdateProfileDto) {
+    return this.usersService.updateProfile(req.user['id'], dto);
+  }
+}

--- a/src/users/dto/query-users.dto.ts
+++ b/src/users/dto/query-users.dto.ts
@@ -1,0 +1,29 @@
+import { IsIn, IsInt, IsOptional, IsString, Min } from 'class-validator';
+import { Type } from 'class-transformer';
+import { UserRole, UserStatus } from '../user.entity';
+
+export class QueryUsersDto {
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @IsOptional()
+  page?: number = 1;
+
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @IsOptional()
+  limit?: number = 20;
+
+  @IsIn(['user', 'professional', 'admin'])
+  @IsOptional()
+  role?: UserRole;
+
+  @IsIn(['active', 'suspended', 'pending'])
+  @IsOptional()
+  status?: UserStatus;
+
+  @IsString()
+  @IsOptional()
+  search?: string;
+}

--- a/src/users/dto/update-profile.dto.ts
+++ b/src/users/dto/update-profile.dto.ts
@@ -1,0 +1,15 @@
+import { IsOptional, IsString } from 'class-validator';
+
+export class UpdateProfileDto {
+  @IsString()
+  @IsOptional()
+  name?: string;
+
+  @IsString()
+  @IsOptional()
+  phone?: string;
+
+  @IsString()
+  @IsOptional()
+  avatar?: string;
+}

--- a/src/users/dto/update-role.dto.ts
+++ b/src/users/dto/update-role.dto.ts
@@ -1,0 +1,12 @@
+import { IsArray, IsIn, IsOptional, IsString } from 'class-validator';
+import { UserRole } from '../user.entity';
+
+export class UpdateRoleDto {
+  @IsIn(['user', 'professional', 'admin'])
+  role: UserRole;
+
+  @IsArray()
+  @IsString({ each: true })
+  @IsOptional()
+  permissions?: string[];
+}

--- a/src/users/dto/update-status.dto.ts
+++ b/src/users/dto/update-status.dto.ts
@@ -1,0 +1,11 @@
+import { IsIn, IsOptional, IsString } from 'class-validator';
+import { UserStatus } from '../user.entity';
+
+export class UpdateStatusDto {
+  @IsIn(['active', 'suspended', 'pending'])
+  status: UserStatus;
+
+  @IsString()
+  @IsOptional()
+  reason?: string;
+}

--- a/src/users/user.entity.ts
+++ b/src/users/user.entity.ts
@@ -1,13 +1,49 @@
-import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn } from 'typeorm';
+
+export type UserRole = 'user' | 'professional' | 'admin';
+export type UserStatus = 'active' | 'suspended' | 'pending';
 
 @Entity()
 export class User {
   @PrimaryGeneratedColumn()
   id: number;
 
+  @Column()
+  name: string;
+
   @Column({ unique: true })
   email: string;
 
   @Column()
   password: string;
+
+  @Column({ default: 'user' })
+  role: UserRole;
+
+  @Column({ default: 'active' })
+  status: UserStatus;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @Column({ type: 'timestamp', nullable: true })
+  lastLogin: Date | null;
+
+  @Column({ default: 0 })
+  orderCount: number;
+
+  @Column({ type: 'float', default: 0 })
+  totalSpent: number;
+
+  @Column({ default: false })
+  isProfessional: boolean;
+
+  @Column({ nullable: true })
+  professionalType: string;
+
+  @Column({ nullable: true })
+  avatar: string;
+
+  @Column({ nullable: true })
+  phone: string;
 }

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -2,10 +2,13 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { User } from './user.entity';
 import { UsersService } from './users.service';
+import { AdminUsersController } from './controllers/admin-users.controller';
+import { ProfileController } from './controllers/profile.controller';
 
 @Module({
   imports: [TypeOrmModule.forFeature([User])],
   providers: [UsersService],
+  controllers: [AdminUsersController, ProfileController],
   exports: [UsersService],
 })
 export class UsersModule {}

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -1,9 +1,13 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { CreateUserDto } from './dto/create-user.dto';
-import { User } from './user.entity';
+import { User, UserRole, UserStatus } from './user.entity';
 import * as bcrypt from 'bcrypt';
+import { QueryUsersDto } from './dto/query-users.dto';
+import { UpdateStatusDto } from './dto/update-status.dto';
+import { UpdateRoleDto } from './dto/update-role.dto';
+import { UpdateProfileDto } from './dto/update-profile.dto';
 
 @Injectable()
 export class UsersService {
@@ -16,11 +20,64 @@ export class UsersService {
     const user = this.usersRepository.create({
       email: dto.email,
       password: await bcrypt.hash(dto.password, 10),
+      name: dto.email.split('@')[0],
     });
     return this.usersRepository.save(user);
   }
 
   async findByEmail(email: string): Promise<User | null> {
     return this.usersRepository.findOne({ where: { email } });
+  }
+
+  async findById(id: number): Promise<User | null> {
+    return this.usersRepository.findOne({ where: { id } });
+  }
+
+  async findAll(query: QueryUsersDto) {
+    const qb = this.usersRepository.createQueryBuilder('user');
+    if (query.role) {
+      qb.andWhere('user.role = :role', { role: query.role });
+    }
+    if (query.status) {
+      qb.andWhere('user.status = :status', { status: query.status });
+    }
+    if (query.search) {
+      qb.andWhere('(user.name ILIKE :search OR user.email ILIKE :search)', {
+        search: `%${query.search}%`,
+      });
+    }
+    const page = query.page ?? 1;
+    const limit = query.limit ?? 20;
+    qb.skip((page - 1) * limit).take(limit);
+
+    const [items, total] = await qb.getManyAndCount();
+    return { users: items, pagination: { total, page, totalPages: Math.ceil(total / limit) } };
+  }
+
+  async updateStatus(id: number, dto: UpdateStatusDto) {
+    const user = await this.findById(id);
+    if (!user) throw new NotFoundException('User not found');
+    user.status = dto.status;
+    return this.usersRepository.save(user);
+  }
+
+  async updateRole(id: number, dto: UpdateRoleDto) {
+    const user = await this.findById(id);
+    if (!user) throw new NotFoundException('User not found');
+    user.role = dto.role;
+    return this.usersRepository.save(user);
+  }
+
+  async updateProfile(id: number, dto: UpdateProfileDto) {
+    const user = await this.findById(id);
+    if (!user) throw new NotFoundException('User not found');
+    if (dto.name !== undefined) user.name = dto.name;
+    if (dto.phone !== undefined) user.phone = dto.phone;
+    if (dto.avatar !== undefined) user.avatar = dto.avatar;
+    return this.usersRepository.save(user);
+  }
+
+  async remove(id: number) {
+    await this.usersRepository.delete(id);
   }
 }

--- a/test/users.e2e-spec.ts
+++ b/test/users.e2e-spec.ts
@@ -1,0 +1,63 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { AppModule } from '../src/app.module';
+import { UsersService } from '../src/users/users.service';
+
+describe('UsersModule (e2e)', () => {
+  let app: INestApplication;
+  let token: string;
+  let adminToken: string;
+  let usersService: UsersService;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    usersService = moduleFixture.get(UsersService);
+    await app.init();
+  });
+
+  it('profile endpoints', async () => {
+    const email = 'user1@example.com';
+    await request(app.getHttpServer())
+      .post('/auth/register')
+      .send({ email, password: 'password' })
+      .expect(201);
+    const res = await request(app.getHttpServer())
+      .post('/auth/login')
+      .send({ email, password: 'password' })
+      .expect(201);
+    token = res.body.access_token;
+
+    await request(app.getHttpServer())
+      .get('/api/profile')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+
+    await request(app.getHttpServer())
+      .put('/api/profile')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name: 'Test User' })
+      .expect(200);
+  });
+
+  it('admin endpoints', async () => {
+    const email = 'admin@example.com';
+    const user = await usersService.create({ email, password: 'password' } as any);
+    user.role = 'admin';
+    await usersService['usersRepository'].save(user);
+    const res = await request(app.getHttpServer())
+      .post('/auth/login')
+      .send({ email, password: 'password' })
+      .expect(201);
+    adminToken = res.body.access_token;
+
+    await request(app.getHttpServer())
+      .get('/api/admin/users')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .expect(200);
+  });
+});


### PR DESCRIPTION
## Summary
- define user entity with role, status and profile fields
- create JWT auth strategy and guards
- implement UsersService with admin and profile features
- add AdminUsersController and ProfileController
- provide DTOs and e2e tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d46ae0d9c832c8a1a2bcc70857b0f