### PR TITLE
Add categories module with admin endpoints

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -3,7 +3,9 @@ import { ConfigModule } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuthModule } from './auth/auth.module';
 import { UsersModule } from './users/users.module';
+import { CategoriesModule } from './categories/categories.module';
 import { User } from './users/user.entity';
+import { Category } from './categories/category.entity';
 
 @Module({
   imports: [
@@ -11,11 +13,12 @@ import { User } from './users/user.entity';
     TypeOrmModule.forRoot({
       type: 'postgres',
       url: process.env.DATABASE_URL,
-      entities: [User],
+      entities: [User, Category],
       synchronize: true,
     }),
     AuthModule,
     UsersModule,
+    CategoriesModule,
   ],
 })
 export class AppModule {}

--- a/src/categories/admin-categories.controller.ts
+++ b/src/categories/admin-categories.controller.ts
@@ -1,0 +1,35 @@
+import { Body, Controller, Delete, Get, Param, Post, Put, Query, UseGuards } from '@nestjs/common';
+import { CategoriesService } from './categories.service';
+import { CreateCategoryDto } from './dto/create-category.dto';
+import { UpdateCategoryDto } from './dto/update-category.dto';
+import { QueryCategoriesDto } from './dto/query-categories.dto';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { RolesGuard } from '../auth/roles.guard';
+import { Roles } from '../auth/roles.decorator';
+
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles('admin')
+@Controller('api/admin/categories')
+export class AdminCategoriesController {
+  constructor(private readonly categoriesService: CategoriesService) {}
+
+  @Get()
+  findAll(@Query() query: QueryCategoriesDto) {
+    return this.categoriesService.findAll(query);
+  }
+
+  @Post()
+  create(@Body() dto: CreateCategoryDto) {
+    return this.categoriesService.create(dto);
+  }
+
+  @Put(':id')
+  update(@Param('id') id: string, @Body() dto: UpdateCategoryDto) {
+    return this.categoriesService.update(id, dto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.categoriesService.remove(id);
+  }
+}

--- a/src/categories/categories.module.ts
+++ b/src/categories/categories.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Category } from './category.entity';
+import { CategoriesService } from './categories.service';
+import { PublicCategoriesController } from './public-categories.controller';
+import { AdminCategoriesController } from './admin-categories.controller';
+import { AuthModule } from '../auth/auth.module';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Category]), AuthModule],
+  providers: [CategoriesService],
+  controllers: [PublicCategoriesController, AdminCategoriesController],
+  exports: [CategoriesService],
+})
+export class CategoriesModule {}

--- a/src/categories/categories.service.ts
+++ b/src/categories/categories.service.ts
@@ -1,0 +1,80 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, IsNull } from 'typeorm';
+import { Category } from './category.entity';
+import { CreateCategoryDto } from './dto/create-category.dto';
+import { UpdateCategoryDto } from './dto/update-category.dto';
+import { QueryCategoriesDto } from './dto/query-categories.dto';
+
+@Injectable()
+export class CategoriesService {
+  constructor(
+    @InjectRepository(Category)
+    private categoriesRepository: Repository<Category>,
+  ) {}
+
+  async create(dto: CreateCategoryDto): Promise<Category> {
+    const category = this.categoriesRepository.create({
+      name: dto.name,
+      description: dto.description,
+      parentId: dto.parentId ?? null,
+    });
+    return this.categoriesRepository.save(category);
+  }
+
+  async findAll(query: QueryCategoriesDto) {
+    const qb = this.categoriesRepository.createQueryBuilder('category');
+    qb.where('category.deletedAt IS NULL');
+    if (query.search) {
+      qb.andWhere('category.name ILIKE :search', { search: `%${query.search}%` });
+    }
+    const page = query.page ?? 1;
+    const limit = query.limit ?? 20;
+    qb.skip((page - 1) * limit).take(limit);
+
+    const [items, total] = await qb.getManyAndCount();
+    return {
+      categories: items,
+      pagination: { total, page, totalPages: Math.ceil(total / limit) },
+    };
+  }
+
+  async findOne(id: string): Promise<Category | null> {
+    return this.categoriesRepository.findOne({ where: { id } });
+  }
+
+  async update(id: string, dto: UpdateCategoryDto): Promise<Category> {
+    const category = await this.findOne(id);
+    if (!category) throw new NotFoundException('Category not found');
+    if (dto.name !== undefined) category.name = dto.name;
+    if (dto.description !== undefined) category.description = dto.description;
+    if (dto.parentId !== undefined) category.parentId = dto.parentId;
+    return this.categoriesRepository.save(category);
+  }
+
+  async remove(id: string, softDelete = true) {
+    if (softDelete) {
+      await this.categoriesRepository.softDelete(id);
+    } else {
+      await this.categoriesRepository.delete(id);
+    }
+  }
+
+  async findTree() {
+    const categories = await this.categoriesRepository.find({
+      where: { deletedAt: IsNull() },
+    });
+    const map = new Map<string, Category & { children: Category[] }>();
+    categories.forEach(c => map.set(c.id, { ...c, children: [] }));
+    const roots: (Category & { children: Category[] })[] = [];
+    map.forEach(cat => {
+      if (cat.parentId) {
+        const parent = map.get(cat.parentId);
+        if (parent) parent.children.push(cat);
+      } else {
+        roots.push(cat);
+      }
+    });
+    return roots;
+  }
+}

--- a/src/categories/category.entity.ts
+++ b/src/categories/category.entity.ts
@@ -1,0 +1,31 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, OneToMany, CreateDateColumn, UpdateDateColumn, DeleteDateColumn } from 'typeorm';
+
+@Entity()
+export class Category {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ unique: true })
+  name: string;
+
+  @Column({ nullable: true })
+  description?: string;
+
+  @Column({ type: 'uuid', nullable: true })
+  parentId?: string | null;
+
+  @ManyToOne(() => Category, category => category.children, { onDelete: 'SET NULL' })
+  parent?: Category;
+
+  @OneToMany(() => Category, category => category.parent)
+  children?: Category[];
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+
+  @DeleteDateColumn()
+  deletedAt?: Date | null;
+}

--- a/src/categories/dto/create-category.dto.ts
+++ b/src/categories/dto/create-category.dto.ts
@@ -1,0 +1,14 @@
+import { IsOptional, IsString, IsUUID } from 'class-validator';
+
+export class CreateCategoryDto {
+  @IsString()
+  name: string;
+
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @IsOptional()
+  @IsUUID()
+  parentId?: string;
+}

--- a/src/categories/dto/query-categories.dto.ts
+++ b/src/categories/dto/query-categories.dto.ts
@@ -1,0 +1,20 @@
+import { IsInt, IsOptional, IsPositive, IsString } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class QueryCategoriesDto {
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @IsPositive()
+  page?: number;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @IsPositive()
+  limit?: number;
+
+  @IsOptional()
+  @IsString()
+  search?: string;
+}

--- a/src/categories/dto/update-category.dto.ts
+++ b/src/categories/dto/update-category.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateCategoryDto } from './create-category.dto';
+
+export class UpdateCategoryDto extends PartialType(CreateCategoryDto) {}

--- a/src/categories/public-categories.controller.ts
+++ b/src/categories/public-categories.controller.ts
@@ -1,0 +1,23 @@
+import { Controller, Get, Param, Query } from '@nestjs/common';
+import { CategoriesService } from './categories.service';
+import { QueryCategoriesDto } from './dto/query-categories.dto';
+
+@Controller('api/categories')
+export class PublicCategoriesController {
+  constructor(private readonly categoriesService: CategoriesService) {}
+
+  @Get()
+  findAll(@Query() query: QueryCategoriesDto) {
+    return this.categoriesService.findAll(query);
+  }
+
+  @Get('tree')
+  findTree() {
+    return this.categoriesService.findTree();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.categoriesService.findOne(id);
+  }
+}

--- a/test/categories.e2e-spec.ts
+++ b/test/categories.e2e-spec.ts
@@ -1,0 +1,70 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { AppModule } from '../src/app.module';
+import { UsersService } from '../src/users/users.service';
+
+describe('CategoriesModule (e2e)', () => {
+  let app: INestApplication;
+  let adminToken: string;
+  let usersService: UsersService;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    usersService = moduleFixture.get(UsersService);
+    await app.init();
+  });
+
+  it('admin endpoints', async () => {
+    const email = 'catadmin@example.com';
+    const user = await usersService.create({ email, password: 'password' } as any);
+    user.role = 'admin';
+    await usersService['usersRepository'].save(user);
+    const res = await request(app.getHttpServer())
+      .post('/auth/login')
+      .send({ email, password: 'password' })
+      .expect(201);
+    adminToken = res.body.access_token;
+
+    const createRes = await request(app.getHttpServer())
+      .post('/api/admin/categories')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ name: 'Cat1' })
+      .expect(201);
+    const id = createRes.body.id;
+
+    await request(app.getHttpServer())
+      .put(`/api/admin/categories/${id}`)
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ description: 'Desc' })
+      .expect(200);
+
+    await request(app.getHttpServer())
+      .get(`/api/categories/${id}`)
+      .expect(200);
+
+    await request(app.getHttpServer())
+      .get('/api/categories')
+      .expect(200);
+
+    await request(app.getHttpServer())
+      .get('/api/categories/tree')
+      .expect(200);
+
+    await request(app.getHttpServer())
+      .delete(`/api/admin/categories/${id}`)
+      .set('Authorization', `Bearer ${adminToken}`)
+      .expect(200);
+  });
+
+  it('should fail without auth on admin routes', () => {
+    return request(app.getHttpServer())
+      .post('/api/admin/categories')
+      .send({ name: 'Fail' })
+      .expect(401);
+  });
+});


### PR DESCRIPTION
## Summary
- implement `Category` entity with self-referencing parent relation
- add `CategoriesService` with CRUD and tree building methods
- add public and admin category controllers
- secure admin routes with `JwtAuthGuard` and `RolesGuard`
- expose categories via new module and include in `AppModule`
- provide DTO classes for validation
- create e2e tests for category endpoints

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d4c216bb8832c99455de2de6004db