### PR TITLE
Add products module

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -6,6 +6,8 @@ import { UsersModule } from './users/users.module';
 import { CategoriesModule } from './categories/categories.module';
 import { User } from './users/user.entity';
 import { Category } from './categories/category.entity';
+import { Product } from './products/product.entity';
+import { ProductsModule } from './products/products.module';
 
 @Module({
   imports: [
@@ -13,12 +15,13 @@ import { Category } from './categories/category.entity';
     TypeOrmModule.forRoot({
       type: 'postgres',
       url: process.env.DATABASE_URL,
-      entities: [User, Category],
+      entities: [User, Category, Product],
       synchronize: true,
     }),
     AuthModule,
     UsersModule,
     CategoriesModule,
+    ProductsModule,
   ],
 })
 export class AppModule {}

--- a/src/products/admin-products.controller.ts
+++ b/src/products/admin-products.controller.ts
@@ -1,0 +1,35 @@
+import { Body, Controller, Delete, Get, Param, Put, Query, UseGuards } from '@nestjs/common';
+import { ProductsService } from './products.service';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { RolesGuard } from '../auth/roles.guard';
+import { Roles } from '../auth/roles.decorator';
+import { QueryProductsDto } from './dto/query-products.dto';
+import { UpdateProductDto } from './dto/update-product.dto';
+import { UpdateStatusDto } from './dto/update-status.dto';
+
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles('admin')
+@Controller('api/admin/products')
+export class AdminProductsController {
+  constructor(private readonly productsService: ProductsService) {}
+
+  @Get()
+  findAll(@Query() query: QueryProductsDto & { status?: string; userId?: number }) {
+    return this.productsService.findAllAdmin(query as any);
+  }
+
+  @Put(':id/status')
+  updateStatus(@Param('id') id: string, @Body() dto: UpdateStatusDto) {
+    return this.productsService.updateStatus(id, dto.status);
+  }
+
+  @Put(':id')
+  update(@Param('id') id: string, @Body() dto: UpdateProductDto) {
+    return this.productsService.update(id, dto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.productsService.remove(id);
+  }
+}

--- a/src/products/dto/create-product.dto.ts
+++ b/src/products/dto/create-product.dto.ts
@@ -1,0 +1,33 @@
+import { IsArray, IsEnum, IsInt, IsNumber, IsOptional, IsString, IsUUID, Min, IsUrl } from 'class-validator';
+import { Type } from 'class-transformer';
+import { ProductStatus } from '../product.entity';
+
+export class CreateProductDto {
+  @IsString()
+  name: string;
+
+  @IsString()
+  description: string;
+
+  @Type(() => Number)
+  @IsNumber()
+  price: number;
+
+  @IsUUID()
+  @IsOptional()
+  categoryId?: string;
+
+  @IsArray()
+  @IsUrl({}, { each: true })
+  @IsOptional()
+  images?: string[];
+
+  @Type(() => Number)
+  @IsInt()
+  @Min(0)
+  stock: number;
+
+  @IsEnum(['active', 'inactive', 'pending'])
+  @IsOptional()
+  status?: ProductStatus;
+}

--- a/src/products/dto/query-products.dto.ts
+++ b/src/products/dto/query-products.dto.ts
@@ -1,0 +1,34 @@
+import { IsInt, IsNumber, IsOptional, IsPositive, IsString, IsUUID, Min } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class QueryProductsDto {
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  limit?: number;
+
+  @IsOptional()
+  @IsUUID()
+  categoryId?: string;
+
+  @IsOptional()
+  @IsString()
+  search?: string;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  minPrice?: number;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  maxPrice?: number;
+}

--- a/src/products/dto/update-product.dto.ts
+++ b/src/products/dto/update-product.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateProductDto } from './create-product.dto';
+
+export class UpdateProductDto extends PartialType(CreateProductDto) {}

--- a/src/products/dto/update-status.dto.ts
+++ b/src/products/dto/update-status.dto.ts
@@ -1,0 +1,11 @@
+import { IsEnum, IsOptional, IsString } from 'class-validator';
+import { ProductStatus } from '../product.entity';
+
+export class UpdateStatusDto {
+  @IsEnum(['active', 'inactive', 'pending'])
+  status: ProductStatus;
+
+  @IsOptional()
+  @IsString()
+  reason?: string;
+}

--- a/src/products/product.entity.ts
+++ b/src/products/product.entity.ts
@@ -1,0 +1,47 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, CreateDateColumn, UpdateDateColumn } from 'typeorm';
+import { Category } from '../categories/category.entity';
+import { User } from '../users/user.entity';
+
+export type ProductStatus = 'active' | 'inactive' | 'pending';
+
+@Entity()
+export class Product {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  name: string;
+
+  @Column('text')
+  description: string;
+
+  @Column('float')
+  price: number;
+
+  @Column({ type: 'uuid', nullable: true })
+  categoryId?: string | null;
+
+  @Column({ type: 'int', nullable: true })
+  userId?: number | null;
+
+  @ManyToOne(() => Category, { nullable: true, onDelete: 'SET NULL' })
+  category?: Category | null;
+
+  @ManyToOne(() => User, { nullable: true, onDelete: 'SET NULL' })
+  user?: User | null;
+
+  @Column('text', { array: true, default: '{}' })
+  images: string[];
+
+  @Column('int')
+  stock: number;
+
+  @Column({ type: 'enum', enum: ['active', 'inactive', 'pending'], default: 'pending' })
+  status: ProductStatus;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/products/products.module.ts
+++ b/src/products/products.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Product } from './product.entity';
+import { ProductsService } from './products.service';
+import { PublicProductsController } from './public-products.controller';
+import { ProfessionalProductsController } from './professional-products.controller';
+import { AdminProductsController } from './admin-products.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Product])],
+  controllers: [PublicProductsController, ProfessionalProductsController, AdminProductsController],
+  providers: [ProductsService],
+})
+export class ProductsModule {}

--- a/src/products/products.service.ts
+++ b/src/products/products.service.ts
@@ -1,0 +1,98 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Product, ProductStatus } from './product.entity';
+import { CreateProductDto } from './dto/create-product.dto';
+import { UpdateProductDto } from './dto/update-product.dto';
+import { QueryProductsDto } from './dto/query-products.dto';
+
+@Injectable()
+export class ProductsService {
+  constructor(
+    @InjectRepository(Product)
+    private productsRepository: Repository<Product>,
+  ) {}
+
+  async findAllPublic(query: QueryProductsDto) {
+    const qb = this.productsRepository.createQueryBuilder('product');
+    qb.where('product.status = :status', { status: 'active' });
+    if (query.categoryId) qb.andWhere('product.categoryId = :cat', { cat: query.categoryId });
+    if (query.search) {
+      qb.andWhere('(product.name ILIKE :search OR product.description ILIKE :search)', { search: `%${query.search}%` });
+    }
+    if (query.minPrice !== undefined)
+      qb.andWhere('product.price >= :min', { min: query.minPrice });
+    if (query.maxPrice !== undefined)
+      qb.andWhere('product.price <= :max', { max: query.maxPrice });
+    const page = query.page ?? 1;
+    const limit = query.limit ?? 20;
+    qb.skip((page - 1) * limit).take(limit);
+    const [items, total] = await qb.getManyAndCount();
+    return { products: items, pagination: { total, page, totalPages: Math.ceil(total / limit) } };
+  }
+
+  async findAllByUser(userId: number, query: QueryProductsDto) {
+    const qb = this.productsRepository.createQueryBuilder('product');
+    qb.where('product.userId = :uid', { uid: userId });
+    const page = query.page ?? 1;
+    const limit = query.limit ?? 20;
+    qb.skip((page - 1) * limit).take(limit);
+    const [items, total] = await qb.getManyAndCount();
+    return { products: items, pagination: { total, page, totalPages: Math.ceil(total / limit) } };
+  }
+
+  async findAllAdmin(query: QueryProductsDto & { status?: ProductStatus; userId?: number }) {
+    const qb = this.productsRepository.createQueryBuilder('product');
+    if (query.status) qb.where('product.status = :status', { status: query.status });
+    if (query.categoryId) qb.andWhere('product.categoryId = :cat', { cat: query.categoryId });
+    if (query.userId !== undefined) qb.andWhere('product.userId = :uid', { uid: query.userId });
+    const page = query.page ?? 1;
+    const limit = query.limit ?? 20;
+    qb.skip((page - 1) * limit).take(limit);
+    const [items, total] = await qb.getManyAndCount();
+    return { products: items, pagination: { total, page, totalPages: Math.ceil(total / limit) } };
+  }
+
+  async findOne(id: string): Promise<Product | null> {
+    return this.productsRepository.findOne({ where: { id } });
+  }
+
+  async create(dto: CreateProductDto): Promise<Product> {
+    const product = this.productsRepository.create({
+      name: dto.name,
+      description: dto.description,
+      price: dto.price,
+      categoryId: dto.categoryId ?? null,
+      userId: (dto as any).userId ?? null,
+      images: dto.images ?? [],
+      stock: dto.stock,
+      status: dto.status ?? 'pending',
+    });
+    return this.productsRepository.save(product);
+  }
+
+  async update(id: string, dto: UpdateProductDto): Promise<Product> {
+    const product = await this.findOne(id);
+    if (!product) throw new NotFoundException('Product not found');
+    if (dto.name !== undefined) product.name = dto.name;
+    if (dto.description !== undefined) product.description = dto.description;
+    if (dto.price !== undefined) product.price = dto.price;
+    if (dto.categoryId !== undefined) product.categoryId = dto.categoryId;
+    if ((dto as any).userId !== undefined) product.userId = (dto as any).userId;
+    if (dto.images !== undefined) product.images = dto.images;
+    if (dto.stock !== undefined) product.stock = dto.stock;
+    if (dto.status !== undefined) product.status = dto.status;
+    return this.productsRepository.save(product);
+  }
+
+  async remove(id: string) {
+    await this.productsRepository.delete(id);
+  }
+
+  async updateStatus(id: string, status: ProductStatus) {
+    const product = await this.findOne(id);
+    if (!product) throw new NotFoundException('Product not found');
+    product.status = status;
+    return this.productsRepository.save(product);
+  }
+}

--- a/src/products/professional-products.controller.ts
+++ b/src/products/professional-products.controller.ts
@@ -1,0 +1,36 @@
+import { Body, Controller, Delete, Get, Param, Post, Put, Query, Req, UseGuards } from '@nestjs/common';
+import { Request } from 'express';
+import { ProductsService } from './products.service';
+import { CreateProductDto } from './dto/create-product.dto';
+import { UpdateProductDto } from './dto/update-product.dto';
+import { QueryProductsDto } from './dto/query-products.dto';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { RolesGuard } from '../auth/roles.guard';
+import { Roles } from '../auth/roles.decorator';
+
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles('professional')
+@Controller('api/professional/products')
+export class ProfessionalProductsController {
+  constructor(private readonly productsService: ProductsService) {}
+
+  @Post()
+  create(@Req() req: Request, @Body() dto: CreateProductDto) {
+    return this.productsService.create({ ...dto, userId: req.user['id'] } as any);
+  }
+
+  @Put(':id')
+  update(@Param('id') id: string, @Body() dto: UpdateProductDto) {
+    return this.productsService.update(id, dto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.productsService.remove(id);
+  }
+
+  @Get()
+  findMine(@Req() req: Request, @Query() query: QueryProductsDto) {
+    return this.productsService.findAllByUser(req.user['id'], query);
+  }
+}

--- a/src/products/public-products.controller.ts
+++ b/src/products/public-products.controller.ts
@@ -1,0 +1,18 @@
+import { Controller, Get, Param, Query } from '@nestjs/common';
+import { ProductsService } from './products.service';
+import { QueryProductsDto } from './dto/query-products.dto';
+
+@Controller('api/products')
+export class PublicProductsController {
+  constructor(private readonly productsService: ProductsService) {}
+
+  @Get()
+  findAll(@Query() query: QueryProductsDto) {
+    return this.productsService.findAllPublic(query);
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.productsService.findOne(id);
+  }
+}

--- a/test/products.e2e-spec.ts
+++ b/test/products.e2e-spec.ts
@@ -1,0 +1,95 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { AppModule } from '../src/app.module';
+import { UsersService } from '../src/users/users.service';
+import { CategoriesService } from '../src/categories/categories.service';
+
+describe('ProductsModule (e2e)', () => {
+  let app: INestApplication;
+  let professionalToken: string;
+  let adminToken: string;
+  let usersService: UsersService;
+  let categoriesService: CategoriesService;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    usersService = moduleFixture.get(UsersService);
+    categoriesService = moduleFixture.get(CategoriesService);
+    await app.init();
+  });
+
+  it('setup users', async () => {
+    const emailPro = 'pro@example.com';
+    const pro = await usersService.create({ email: emailPro, password: 'pass' } as any);
+    pro.role = 'professional';
+    await usersService['usersRepository'].save(pro);
+    const resPro = await request(app.getHttpServer())
+      .post('/auth/login')
+      .send({ email: emailPro, password: 'pass' })
+      .expect(201);
+    professionalToken = resPro.body.access_token;
+
+    const emailAdmin = 'admin2@example.com';
+    const admin = await usersService.create({ email: emailAdmin, password: 'pass' } as any);
+    admin.role = 'admin';
+    await usersService['usersRepository'].save(admin);
+    const resAdmin = await request(app.getHttpServer())
+      .post('/auth/login')
+      .send({ email: emailAdmin, password: 'pass' })
+      .expect(201);
+    adminToken = resAdmin.body.access_token;
+  });
+
+  it('professional product CRUD', async () => {
+    const cat = await categoriesService.create({ name: 'ProdCat' });
+    const createRes = await request(app.getHttpServer())
+      .post('/api/professional/products')
+      .set('Authorization', `Bearer ${professionalToken}`)
+      .send({
+        name: 'Prod1',
+        description: 'desc',
+        price: 10,
+        categoryId: cat.id,
+        stock: 5,
+        status: 'active',
+      })
+      .expect(201);
+    const id = createRes.body.id;
+
+    await request(app.getHttpServer())
+      .put(`/api/professional/products/${id}`)
+      .set('Authorization', `Bearer ${professionalToken}`)
+      .send({ price: 12 })
+      .expect(200);
+
+    await request(app.getHttpServer())
+      .get('/api/professional/products')
+      .set('Authorization', `Bearer ${professionalToken}`)
+      .expect(200);
+
+    await request(app.getHttpServer())
+      .delete(`/api/professional/products/${id}`)
+      .set('Authorization', `Bearer ${professionalToken}`)
+      .expect(200);
+  });
+
+  it('public and admin endpoints', async () => {
+    await request(app.getHttpServer()).get('/api/products').expect(200);
+    await request(app.getHttpServer())
+      .get('/api/admin/products')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .expect(200);
+  });
+
+  it('should fail without auth', () => {
+    return request(app.getHttpServer())
+      .post('/api/professional/products')
+      .send({ name: 'Fail', description: 'x', price: 1, stock: 1 })
+      .expect(401);
+  });
+});


### PR DESCRIPTION
## Summary
- create Product entity and DTOs
- implement ProductsService with CRUD and filtering methods
- add public, professional and admin controllers with role-based security
- register ProductsModule in AppModule
- add e2e tests for product endpoints

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d5c2a11f8832c95e768c93d1decf2