### PR TITLE
Add orders module with PostgreSQL integration

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -8,6 +8,8 @@ import { User } from './users/user.entity';
 import { Category } from './categories/category.entity';
 import { Product } from './products/product.entity';
 import { ProductsModule } from './products/products.module';
+import { Order } from './orders/order.entity';
+import { OrdersModule } from './orders/orders.module';
 
 @Module({
   imports: [
@@ -15,13 +17,14 @@ import { ProductsModule } from './products/products.module';
     TypeOrmModule.forRoot({
       type: 'postgres',
       url: process.env.DATABASE_URL,
-      entities: [User, Category, Product],
+      entities: [User, Category, Product, Order],
       synchronize: true,
     }),
     AuthModule,
     UsersModule,
     CategoriesModule,
     ProductsModule,
+    OrdersModule,
   ],
 })
 export class AppModule {}

--- a/src/orders/admin-orders.controller.ts
+++ b/src/orders/admin-orders.controller.ts
@@ -1,0 +1,24 @@
+import { Body, Controller, Get, Param, Put, Query, UseGuards } from '@nestjs/common';
+import { OrdersService } from './orders.service';
+import { QueryAdminOrdersDto } from './dto/query-orders.dto';
+import { UpdateStatusDto } from './dto/update-status.dto';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { RolesGuard } from '../auth/roles.guard';
+import { Roles } from '../auth/roles.decorator';
+
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles('admin')
+@Controller('api/admin/orders')
+export class AdminOrdersController {
+  constructor(private readonly ordersService: OrdersService) {}
+
+  @Get()
+  findAll(@Query() query: QueryAdminOrdersDto) {
+    return this.ordersService.findAllAdmin(query);
+  }
+
+  @Put(':id/status')
+  updateStatus(@Param('id') id: string, @Body() dto: UpdateStatusDto) {
+    return this.ordersService.updateStatus(id, dto.status);
+  }
+}

--- a/src/orders/dto/create-order.dto.ts
+++ b/src/orders/dto/create-order.dto.ts
@@ -1,0 +1,23 @@
+import { IsArray, IsInt, IsNumber, IsUUID, Min, ValidateNested } from 'class-validator';
+import { Type } from 'class-transformer';
+
+class OrderItemDto {
+  @IsUUID()
+  productId: string;
+
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  quantity: number;
+
+  @Type(() => Number)
+  @IsNumber()
+  price: number;
+}
+
+export class CreateOrderDto {
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => OrderItemDto)
+  items: OrderItemDto[];
+}

--- a/src/orders/dto/query-orders.dto.ts
+++ b/src/orders/dto/query-orders.dto.ts
@@ -1,0 +1,23 @@
+import { IsIn, IsInt, IsOptional, Min } from 'class-validator';
+import { Type } from 'class-transformer';
+import { OrderStatus } from '../order.entity';
+
+export class QueryOrdersDto {
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  limit?: number;
+}
+
+export class QueryAdminOrdersDto extends QueryOrdersDto {
+  @IsOptional()
+  @IsIn(['pending', 'paid', 'shipped', 'delivered'])
+  status?: OrderStatus;
+}

--- a/src/orders/dto/update-status.dto.ts
+++ b/src/orders/dto/update-status.dto.ts
@@ -1,0 +1,7 @@
+import { IsEnum } from 'class-validator';
+import { OrderStatus } from '../order.entity';
+
+export class UpdateStatusDto {
+  @IsEnum(['pending', 'paid', 'shipped', 'delivered'])
+  status: OrderStatus;
+}

--- a/src/orders/order.entity.ts
+++ b/src/orders/order.entity.ts
@@ -1,0 +1,37 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, CreateDateColumn, UpdateDateColumn } from 'typeorm';
+import { User } from '../users/user.entity';
+
+export type OrderStatus = 'pending' | 'paid' | 'shipped' | 'delivered';
+
+export interface OrderItem {
+  productId: string;
+  quantity: number;
+  price: number;
+}
+
+@Entity()
+export class Order {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column('int')
+  userId: number;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  user: User;
+
+  @Column('jsonb')
+  items: OrderItem[];
+
+  @Column('float')
+  total: number;
+
+  @Column({ type: 'enum', enum: ['pending', 'paid', 'shipped', 'delivered'], default: 'pending' })
+  status: OrderStatus;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/orders/orders.controller.ts
+++ b/src/orders/orders.controller.ts
@@ -1,0 +1,27 @@
+import { Body, Controller, Get, Param, Post, Query, Req, UseGuards } from '@nestjs/common';
+import { Request } from 'express';
+import { OrdersService } from './orders.service';
+import { CreateOrderDto } from './dto/create-order.dto';
+import { QueryOrdersDto } from './dto/query-orders.dto';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+
+@UseGuards(JwtAuthGuard)
+@Controller('api/orders')
+export class OrdersController {
+  constructor(private readonly ordersService: OrdersService) {}
+
+  @Post()
+  create(@Req() req: Request, @Body() dto: CreateOrderDto) {
+    return this.ordersService.createOrder(req.user['id'], dto);
+  }
+
+  @Get()
+  findAll(@Req() req: Request, @Query() query: QueryOrdersDto) {
+    return this.ordersService.findAllByUser(req.user['id'], query);
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.ordersService.findOne(id);
+  }
+}

--- a/src/orders/orders.module.ts
+++ b/src/orders/orders.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Order } from './order.entity';
+import { OrdersService } from './orders.service';
+import { OrdersController } from './orders.controller';
+import { AdminOrdersController } from './admin-orders.controller';
+import { AuthModule } from '../auth/auth.module';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Order]), AuthModule],
+  providers: [OrdersService],
+  controllers: [OrdersController, AdminOrdersController],
+  exports: [OrdersService],
+})
+export class OrdersModule {}

--- a/src/orders/orders.service.ts
+++ b/src/orders/orders.service.ts
@@ -1,0 +1,56 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Order, OrderStatus } from './order.entity';
+import { CreateOrderDto } from './dto/create-order.dto';
+import { QueryAdminOrdersDto, QueryOrdersDto } from './dto/query-orders.dto';
+
+@Injectable()
+export class OrdersService {
+  constructor(
+    @InjectRepository(Order)
+    private ordersRepository: Repository<Order>,
+  ) {}
+
+  async createOrder(userId: number, dto: CreateOrderDto) {
+    const total = dto.items.reduce((sum, item) => sum + item.price * item.quantity, 0);
+    const order = this.ordersRepository.create({
+      userId,
+      items: dto.items,
+      total,
+      status: 'pending',
+    });
+    return this.ordersRepository.save(order);
+  }
+
+  async findAllByUser(userId: number, query: QueryOrdersDto) {
+    const qb = this.ordersRepository.createQueryBuilder('order');
+    qb.where('order.userId = :uid', { uid: userId });
+    const page = query.page ?? 1;
+    const limit = query.limit ?? 20;
+    qb.skip((page - 1) * limit).take(limit);
+    const [items, total] = await qb.getManyAndCount();
+    return { orders: items, pagination: { total, page, totalPages: Math.ceil(total / limit) } };
+  }
+
+  async findAllAdmin(query: QueryAdminOrdersDto) {
+    const qb = this.ordersRepository.createQueryBuilder('order');
+    if (query.status) qb.where('order.status = :status', { status: query.status });
+    const page = query.page ?? 1;
+    const limit = query.limit ?? 20;
+    qb.skip((page - 1) * limit).take(limit);
+    const [items, total] = await qb.getManyAndCount();
+    return { orders: items, pagination: { total, page, totalPages: Math.ceil(total / limit) } };
+  }
+
+  async findOne(id: string) {
+    return this.ordersRepository.findOne({ where: { id } });
+  }
+
+  async updateStatus(id: string, status: OrderStatus) {
+    const order = await this.findOne(id);
+    if (!order) throw new NotFoundException('Order not found');
+    order.status = status;
+    return this.ordersRepository.save(order);
+  }
+}

--- a/test/orders.e2e-spec.ts
+++ b/test/orders.e2e-spec.ts
@@ -1,0 +1,102 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { AppModule } from '../src/app.module';
+import { UsersService } from '../src/users/users.service';
+
+describe('OrdersModule (e2e)', () => {
+  let app: INestApplication;
+  let userToken: string;
+  let adminToken: string;
+  let usersService: UsersService;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    usersService = moduleFixture.get(UsersService);
+    await app.init();
+  });
+
+  it('order flow', async () => {
+    const emailUser = 'orderuser@example.com';
+    await request(app.getHttpServer())
+      .post('/auth/register')
+      .send({ email: emailUser, password: 'pass' })
+      .expect(201);
+    const resUser = await request(app.getHttpServer())
+      .post('/auth/login')
+      .send({ email: emailUser, password: 'pass' })
+      .expect(201);
+    userToken = resUser.body.access_token;
+
+    const createRes = await request(app.getHttpServer())
+      .post('/api/orders')
+      .set('Authorization', `Bearer ${userToken}`)
+      .send({
+        items: [
+          {
+            productId: '11111111-1111-1111-1111-111111111111',
+            quantity: 2,
+            price: 5,
+          },
+        ],
+      })
+      .expect(201);
+    const id = createRes.body.id;
+
+    await request(app.getHttpServer())
+      .get('/api/orders')
+      .set('Authorization', `Bearer ${userToken}`)
+      .expect(200);
+
+    await request(app.getHttpServer())
+      .get(`/api/orders/${id}`)
+      .set('Authorization', `Bearer ${userToken}`)
+      .expect(200);
+
+    const emailAdmin = 'orderadmin@example.com';
+    const admin = await usersService.create({ email: emailAdmin, password: 'pass' } as any);
+    admin.role = 'admin';
+    await usersService['usersRepository'].save(admin);
+    const resAdmin = await request(app.getHttpServer())
+      .post('/auth/login')
+      .send({ email: emailAdmin, password: 'pass' })
+      .expect(201);
+    adminToken = resAdmin.body.access_token;
+
+    await request(app.getHttpServer())
+      .get('/api/admin/orders')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .expect(200);
+
+    await request(app.getHttpServer())
+      .put(`/api/admin/orders/${id}/status`)
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ status: 'paid' })
+      .expect(200);
+  });
+
+  it('should fail without auth', () => {
+    return request(app.getHttpServer()).get('/api/orders').expect(401);
+  });
+
+  it('should forbid non admin', async () => {
+    const email = 'regular@example.com';
+    await request(app.getHttpServer())
+      .post('/auth/register')
+      .send({ email, password: 'pass' })
+      .expect(201);
+    const res = await request(app.getHttpServer())
+      .post('/auth/login')
+      .send({ email, password: 'pass' })
+      .expect(201);
+    const token = res.body.access_token;
+    await request(app.getHttpServer())
+      .get('/api/admin/orders')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(403);
+  });
+});


### PR DESCRIPTION
## Summary
- implement `orders` module with TypeORM entity
- create DTOs and service logic for order management
- add client and admin controllers with guards
- register module and entity in `AppModule`
- provide e2e tests for the new endpoints

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d5e2cb340832c90a63b88f3cba2a5