### PR TITLE
Add profile module

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -10,6 +10,7 @@ import { Product } from './products/product.entity';
 import { ProductsModule } from './products/products.module';
 import { Order } from './orders/order.entity';
 import { OrdersModule } from './orders/orders.module';
+import { ProfileModule } from './profile/profile.module';
 
 @Module({
   imports: [
@@ -25,6 +26,7 @@ import { OrdersModule } from './orders/orders.module';
     CategoriesModule,
     ProductsModule,
     OrdersModule,
+    ProfileModule,
   ],
 })
 export class AppModule {}

--- a/src/common/decorators/current-user.decorator.ts
+++ b/src/common/decorators/current-user.decorator.ts
@@ -1,0 +1,8 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+
+export const CurrentUser = createParamDecorator(
+  (data: unknown, ctx: ExecutionContext) => {
+    const request = ctx.switchToHttp().getRequest();
+    return request.user;
+  },
+);

--- a/src/profile/dto/update-profile.dto.ts
+++ b/src/profile/dto/update-profile.dto.ts
@@ -1,0 +1,16 @@
+import { IsNotEmpty, IsOptional, IsPhoneNumber, IsUrl, IsString } from 'class-validator';
+
+export class UpdateProfileDto {
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  name?: string;
+
+  @IsOptional()
+  @IsPhoneNumber(null)
+  phone?: string;
+
+  @IsOptional()
+  @IsUrl()
+  avatar?: string;
+}

--- a/src/profile/profile.controller.ts
+++ b/src/profile/profile.controller.ts
@@ -1,0 +1,22 @@
+import { Controller, Get, Put, Body, UseGuards, UsePipes, ValidationPipe } from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { CurrentUser } from '../common/decorators/current-user.decorator';
+import { ProfileService } from './profile.service';
+import { UpdateProfileDto } from './dto/update-profile.dto';
+
+@UseGuards(JwtAuthGuard)
+@Controller('api/profile')
+export class ProfileController {
+  constructor(private readonly profileService: ProfileService) {}
+
+  @Get()
+  getProfile(@CurrentUser() user: any) {
+    return this.profileService.getProfile(user.id);
+  }
+
+  @Put()
+  @UsePipes(new ValidationPipe({ whitelist: true, errorHttpStatusCode: 422 }))
+  updateProfile(@CurrentUser() user: any, @Body() dto: UpdateProfileDto) {
+    return this.profileService.updateProfile(user.id, dto);
+  }
+}

--- a/src/profile/profile.module.ts
+++ b/src/profile/profile.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { User } from '../users/user.entity';
+import { ProfileService } from './profile.service';
+import { ProfileController } from './profile.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([User])],
+  providers: [ProfileService],
+  controllers: [ProfileController],
+})
+export class ProfileModule {}

--- a/src/profile/profile.service.ts
+++ b/src/profile/profile.service.ts
@@ -1,0 +1,31 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { User } from '../users/user.entity';
+import { UpdateProfileDto } from './dto/update-profile.dto';
+
+@Injectable()
+export class ProfileService {
+  constructor(
+    @InjectRepository(User)
+    private readonly usersRepository: Repository<User>,
+  ) {}
+
+  async getProfile(userId: number) {
+    const user = await this.usersRepository.findOne({ where: { id: userId } });
+    if (!user) return null;
+    const { id, name, email, isProfessional, professionalType, avatar, phone } = user;
+    return { id, name, email, isProfessional, professionalType, avatar, phone };
+  }
+
+  async updateProfile(userId: number, dto: UpdateProfileDto) {
+    const user = await this.usersRepository.findOne({ where: { id: userId } });
+    if (!user) throw new NotFoundException('User not found');
+    if (dto.name !== undefined) user.name = dto.name;
+    if (dto.phone !== undefined) user.phone = dto.phone;
+    if (dto.avatar !== undefined) user.avatar = dto.avatar;
+    await this.usersRepository.save(user);
+    const { id, name, email, isProfessional, professionalType, avatar, phone } = user;
+    return { id, name, email, isProfessional, professionalType, avatar, phone };
+  }
+}

--- a/test/profile.e2e-spec.ts
+++ b/test/profile.e2e-spec.ts
@@ -1,0 +1,57 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { AppModule } from '../src/app.module';
+
+describe('ProfileModule (e2e)', () => {
+  let app: INestApplication;
+  let token: string;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+  });
+
+  it('should require auth', () => {
+    return request(app.getHttpServer()).get('/api/profile').expect(401);
+  });
+
+  it('should get and update profile', async () => {
+    const email = 'profile@example.com';
+    await request(app.getHttpServer())
+      .post('/auth/register')
+      .send({ email, password: 'password' })
+      .expect(201);
+    const res = await request(app.getHttpServer())
+      .post('/auth/login')
+      .send({ email, password: 'password' })
+      .expect(201);
+    token = res.body.access_token;
+
+    const getRes = await request(app.getHttpServer())
+      .get('/api/profile')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+    expect(getRes.body.email).toBe(email);
+
+    const updateRes = await request(app.getHttpServer())
+      .put('/api/profile')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name: 'New Name' })
+      .expect(200);
+    expect(updateRes.body.name).toBe('New Name');
+  });
+
+  it('should fail validation', async () => {
+    const res = await request(app.getHttpServer())
+      .put('/api/profile')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ phone: 'invalid' })
+      .expect(422);
+    expect(res.body.message).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add `ProfileModule` with service, controller and DTOs
- create custom `CurrentUser` decorator
- register the module
- add e2e tests for profile routes

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685d5f9ee3e0832c948df91a72836bd4