### PR TITLE
Add professional module

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -13,6 +13,8 @@ import { Order } from './orders/order.entity';
 import { OrdersModule } from './orders/orders.module';
 import { ProfileModule } from './profile/profile.module';
 import { SearchModule } from './search/search.module';
+import { ProfessionalRequest } from './professional/professional-request.entity';
+import { ProfessionalModule } from './professional/professional.module';
 
 @Module({
   imports: [
@@ -20,7 +22,7 @@ import { SearchModule } from './search/search.module';
     TypeOrmModule.forRoot({
       type: 'postgres',
       url: process.env.DATABASE_URL,
-      entities: [User, Category, Product, Service, Order],
+      entities: [User, Category, Product, Service, Order, ProfessionalRequest],
       synchronize: true,
     }),
     AuthModule,
@@ -30,6 +32,7 @@ import { SearchModule } from './search/search.module';
     OrdersModule,
     ProfileModule,
     SearchModule,
+    ProfessionalModule,
   ],
 })
 export class AppModule {}

--- a/src/orders/order.entity.ts
+++ b/src/orders/order.entity.ts
@@ -26,6 +26,9 @@ export class Order {
   @Column('float')
   total: number;
 
+  @Column({ nullable: true })
+  trackingNumber?: string;
+
   @Column({ type: 'enum', enum: ['pending', 'paid', 'shipped', 'delivered'], default: 'pending' })
   status: OrderStatus;
 

--- a/src/professional/dto/request-professional.dto.ts
+++ b/src/professional/dto/request-professional.dto.ts
@@ -1,0 +1,18 @@
+import { IsEmail, IsNotEmpty, IsString } from 'class-validator';
+
+export class RequestProfessionalDto {
+  @IsString()
+  @IsNotEmpty()
+  companyName: string;
+
+  @IsString()
+  @IsNotEmpty()
+  accountType: string;
+
+  @IsString()
+  @IsNotEmpty()
+  description: string;
+
+  @IsEmail()
+  email: string;
+}

--- a/src/professional/dto/update-order-status.dto.ts
+++ b/src/professional/dto/update-order-status.dto.ts
@@ -1,0 +1,11 @@
+import { IsEnum, IsOptional, IsString } from 'class-validator';
+import { OrderStatus } from '../../orders/order.entity';
+
+export class UpdateOrderStatusDto {
+  @IsEnum(['pending', 'paid', 'shipped', 'delivered'])
+  status: OrderStatus;
+
+  @IsOptional()
+  @IsString()
+  trackingNumber?: string;
+}

--- a/src/professional/professional-request.entity.ts
+++ b/src/professional/professional-request.entity.ts
@@ -1,0 +1,30 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn } from 'typeorm';
+
+export type ProfessionalRequestStatus = 'pending' | 'approved' | 'rejected';
+
+@Entity()
+export class ProfessionalRequest {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column('uuid')
+  userId: string;
+
+  @Column()
+  companyName: string;
+
+  @Column()
+  accountType: string;
+
+  @Column('text')
+  description: string;
+
+  @Column({ type: 'enum', enum: ['pending', 'approved', 'rejected'], default: 'pending' })
+  status: ProfessionalRequestStatus;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/professional/professional.controller.ts
+++ b/src/professional/professional.controller.ts
@@ -1,0 +1,47 @@
+import { Body, Controller, Get, Post, Put, Query, Param, UseGuards, UsePipes, ValidationPipe } from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { RolesGuard } from '../auth/roles.guard';
+import { Roles } from '../auth/roles.decorator';
+import { CurrentUser } from '../common/decorators/current-user.decorator';
+import { ProfessionalService } from './professional.service';
+import { RequestProfessionalDto } from './dto/request-professional.dto';
+import { UpdateOrderStatusDto } from './dto/update-order-status.dto';
+
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles('professional')
+@Controller('api/professional')
+export class ProfessionalController {
+  constructor(private readonly professionalService: ProfessionalService) {}
+
+  @Post('request')
+  @UsePipes(new ValidationPipe({ whitelist: true }))
+  requestProfessional(@CurrentUser() user: any, @Body() dto: RequestProfessionalDto) {
+    return this.professionalService.requestProfessional(user.id, dto);
+  }
+
+  @Get('products')
+  findProProducts(@CurrentUser() user: any, @Query('page') page?: number, @Query('limit') limit?: number) {
+    return this.professionalService.findProProducts(user.id, { page: page ? +page : undefined, limit: limit ? +limit : undefined });
+  }
+
+  @Get('services')
+  findProServices(@CurrentUser() user: any, @Query('page') page?: number, @Query('limit') limit?: number) {
+    return this.professionalService.findProServices(user.id, { page: page ? +page : undefined, limit: limit ? +limit : undefined });
+  }
+
+  @Get('orders')
+  findProOrders(
+    @CurrentUser() user: any,
+    @Query('status') status?: string,
+    @Query('page') page?: number,
+    @Query('limit') limit?: number,
+  ) {
+    return this.professionalService.findProOrders(user.id, { status, page: page ? +page : undefined, limit: limit ? +limit : undefined });
+  }
+
+  @Put('orders/:orderId/status')
+  @UsePipes(new ValidationPipe({ whitelist: true }))
+  updateOrderStatus(@Param('orderId') orderId: string, @Body() dto: UpdateOrderStatusDto) {
+    return this.professionalService.updateOrderStatus(orderId, dto);
+  }
+}

--- a/src/professional/professional.module.ts
+++ b/src/professional/professional.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ProfessionalRequest } from './professional-request.entity';
+import { ProfessionalService } from './professional.service';
+import { ProfessionalController } from './professional.controller';
+import { Product } from '../products/product.entity';
+import { Service } from '../services/service.entity';
+import { Order } from '../orders/order.entity';
+import { AuthModule } from '../auth/auth.module';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([ProfessionalRequest, Product, Service, Order]), AuthModule],
+  providers: [ProfessionalService],
+  controllers: [ProfessionalController],
+})
+export class ProfessionalModule {}

--- a/src/professional/professional.service.ts
+++ b/src/professional/professional.service.ts
@@ -1,0 +1,73 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { ProfessionalRequest } from './professional-request.entity';
+import { RequestProfessionalDto } from './dto/request-professional.dto';
+import { UpdateOrderStatusDto } from './dto/update-order-status.dto';
+import { Product } from '../products/product.entity';
+import { Service as ServiceEntity } from '../services/service.entity';
+import { Order } from '../orders/order.entity';
+
+@Injectable()
+export class ProfessionalService {
+  constructor(
+    @InjectRepository(ProfessionalRequest)
+    private requestsRepository: Repository<ProfessionalRequest>,
+    @InjectRepository(Product)
+    private productsRepository: Repository<Product>,
+    @InjectRepository(ServiceEntity)
+    private servicesRepository: Repository<ServiceEntity>,
+    @InjectRepository(Order)
+    private ordersRepository: Repository<Order>,
+  ) {}
+
+  async requestProfessional(userId: string, dto: RequestProfessionalDto) {
+    const req = this.requestsRepository.create({
+      userId,
+      companyName: dto.companyName,
+      accountType: dto.accountType,
+      description: dto.description,
+      status: 'pending',
+    });
+    return this.requestsRepository.save(req);
+  }
+
+  async findProProducts(userId: string, query: { page?: number; limit?: number }) {
+    const qb = this.productsRepository.createQueryBuilder('product');
+    qb.where('product.userId = :uid', { uid: userId });
+    const page = query.page ?? 1;
+    const limit = query.limit ?? 20;
+    qb.skip((page - 1) * limit).take(limit);
+    const [items, total] = await qb.getManyAndCount();
+    return { products: items, pagination: { total, page, totalPages: Math.ceil(total / limit) } };
+  }
+
+  async findProServices(userId: string, query: { page?: number; limit?: number }) {
+    const qb = this.servicesRepository.createQueryBuilder('service');
+    qb.where('service.userId = :uid', { uid: userId });
+    const page = query.page ?? 1;
+    const limit = query.limit ?? 20;
+    qb.skip((page - 1) * limit).take(limit);
+    const [items, total] = await qb.getManyAndCount();
+    return { services: items, pagination: { total, page, totalPages: Math.ceil(total / limit) } };
+  }
+
+  async findProOrders(userId: string, query: { status?: string; page?: number; limit?: number }) {
+    const qb = this.ordersRepository.createQueryBuilder('order');
+    qb.where('order.userId = :uid', { uid: userId });
+    if (query.status) qb.andWhere('order.status = :status', { status: query.status });
+    const page = query.page ?? 1;
+    const limit = query.limit ?? 20;
+    qb.skip((page - 1) * limit).take(limit);
+    const [items, total] = await qb.getManyAndCount();
+    return { orders: items, pagination: { total, page, totalPages: Math.ceil(total / limit) } };
+  }
+
+  async updateOrderStatus(orderId: string, dto: UpdateOrderStatusDto) {
+    const order = await this.ordersRepository.findOne({ where: { id: orderId } });
+    if (!order) throw new NotFoundException('Order not found');
+    order.status = dto.status;
+    if (dto.trackingNumber !== undefined) order['trackingNumber'] = dto.trackingNumber;
+    return this.ordersRepository.save(order);
+  }
+}

--- a/test/professional.e2e-spec.ts
+++ b/test/professional.e2e-spec.ts
@@ -1,0 +1,118 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { AppModule } from '../src/app.module';
+import { UsersService } from '../src/users/users.service';
+import { OrdersService } from '../src/orders/orders.service';
+
+describe('ProfessionalModule (e2e)', () => {
+  let app: INestApplication;
+  let professionalToken: string;
+  let usersService: UsersService;
+  let ordersService: OrdersService;
+  let orderId: string;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    usersService = moduleFixture.get(UsersService);
+    ordersService = moduleFixture.get(OrdersService);
+    await app.init();
+  });
+
+  it('setup professional user', async () => {
+    const email = 'proreq@example.com';
+    const user = await usersService.create({ email, password: 'pass' } as any);
+    user.role = 'professional';
+    await usersService['usersRepository'].save(user);
+    const res = await request(app.getHttpServer())
+      .post('/auth/login')
+      .send({ email, password: 'pass' })
+      .expect(201);
+    professionalToken = res.body.access_token;
+  });
+
+  it('request professional status', async () => {
+    await request(app.getHttpServer())
+      .post('/api/professional/request')
+      .set('Authorization', `Bearer ${professionalToken}`)
+      .send({
+        companyName: 'Comp',
+        accountType: 'seller',
+        description: 'desc',
+        email: 'contact@example.com',
+      })
+      .expect(201);
+  });
+
+  it('products, services and orders', async () => {
+    await request(app.getHttpServer())
+      .get('/api/professional/products')
+      .set('Authorization', `Bearer ${professionalToken}`)
+      .expect(200);
+
+    await request(app.getHttpServer())
+      .get('/api/professional/services')
+      .set('Authorization', `Bearer ${professionalToken}`)
+      .expect(200);
+
+    const order = await ordersService.createOrder(userId(professionalToken), {
+      items: [{ productId: '11111111-1111-1111-1111-111111111111', quantity: 1, price: 5 }],
+    } as any);
+    orderId = order.id;
+
+    await request(app.getHttpServer())
+      .get('/api/professional/orders')
+      .set('Authorization', `Bearer ${professionalToken}`)
+      .expect(200);
+
+    await request(app.getHttpServer())
+      .put(`/api/professional/orders/${orderId}/status`)
+      .set('Authorization', `Bearer ${professionalToken}`)
+      .send({ status: 'shipped' })
+      .expect(200);
+  });
+
+  it('should fail unauthorized', () => {
+    return request(app.getHttpServer()).get('/api/professional/products').expect(401);
+  });
+
+  it('should forbid non professional', async () => {
+    const email = 'regularpro@example.com';
+    await usersService.create({ email, password: 'pass' } as any);
+    const res = await request(app.getHttpServer())
+      .post('/auth/login')
+      .send({ email, password: 'pass' })
+      .expect(201);
+    const token = res.body.access_token;
+    await request(app.getHttpServer())
+      .get('/api/professional/products')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(403);
+  });
+
+  it('should return 400 on bad request', async () => {
+    await request(app.getHttpServer())
+      .post('/api/professional/request')
+      .set('Authorization', `Bearer ${professionalToken}`)
+      .send({})
+      .expect(400);
+  });
+
+  it('should return 404 for unknown order', () => {
+    return request(app.getHttpServer())
+      .put('/api/professional/orders/unknown/status')
+      .set('Authorization', `Bearer ${professionalToken}`)
+      .send({ status: 'paid' })
+      .expect(404);
+  });
+});
+
+function userId(token: string): any {
+  // simple helper to decode payload { sub: id }
+  const payload = JSON.parse(Buffer.from(token.split('.')[1], 'base64').toString());
+  return payload.sub;
+}


### PR DESCRIPTION
## Summary
- implement ProfessionalRequest entity and service
- create professional controller and module
- extend Order entity with trackingNumber
- wire ProfessionalModule in app
- add basic e2e tests for professional endpoints

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d641714f8832c92f50c650261f133