### PR TITLE
Implement admin module with slides and promotions

### DIFF
--- a/src/admin/admin.module.ts
+++ b/src/admin/admin.module.ts
@@ -1,0 +1,23 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { HeroSlide } from './hero-slide.entity';
+import { Promotion } from './promotion.entity';
+import { HeroSlidesService } from './hero-slides.service';
+import { PromotionsService } from './promotions.service';
+import { HeroSlidesController } from './hero-slides.controller';
+import { PromotionsController } from './promotions.controller';
+import { DashboardController } from './dashboard.controller';
+import { DashboardService } from './dashboard.service';
+import { User } from '../users/user.entity';
+import { Order } from '../orders/order.entity';
+import { Product } from '../products/product.entity';
+import { ProfessionalRequest } from '../professional/professional-request.entity';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([HeroSlide, Promotion, User, Order, Product, ProfessionalRequest]),
+  ],
+  controllers: [HeroSlidesController, PromotionsController, DashboardController],
+  providers: [HeroSlidesService, PromotionsService, DashboardService],
+})
+export class AdminModule {}

--- a/src/admin/dashboard.controller.ts
+++ b/src/admin/dashboard.controller.ts
@@ -1,0 +1,17 @@
+import { Controller, Get, UseGuards } from '@nestjs/common';
+import { DashboardService } from './dashboard.service';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { RolesGuard } from '../auth/roles.guard';
+import { Roles } from '../auth/roles.decorator';
+
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles('admin')
+@Controller('api/admin/dashboard')
+export class DashboardController {
+  constructor(private readonly dashboardService: DashboardService) {}
+
+  @Get()
+  getStats() {
+    return this.dashboardService.getStats();
+  }
+}

--- a/src/admin/dashboard.service.ts
+++ b/src/admin/dashboard.service.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { User } from '../users/user.entity';
+import { Order } from '../orders/order.entity';
+import { Product } from '../products/product.entity';
+import { ProfessionalRequest } from '../professional/professional-request.entity';
+
+@Injectable()
+export class DashboardService {
+  constructor(
+    @InjectRepository(User) private usersRepo: Repository<User>,
+    @InjectRepository(Order) private ordersRepo: Repository<Order>,
+    @InjectRepository(Product) private productsRepo: Repository<Product>,
+    @InjectRepository(ProfessionalRequest) private requestsRepo: Repository<ProfessionalRequest>,
+  ) {}
+
+  async getStats() {
+    const totalUsers = await this.usersRepo.count();
+    const totalOrders = await this.ordersRepo.count();
+    const { sum } = await this.ordersRepo
+      .createQueryBuilder('order')
+      .select('SUM(order.total)', 'sum')
+      .getRawOne<{ sum: string }>();
+    const totalRevenue = Number(sum) || 0;
+    const activeProducts = await this.productsRepo.count({ where: { status: 'active' } });
+    const pendingRequests = await this.requestsRepo.count({ where: { status: 'pending' } });
+    return { totalUsers, totalOrders, totalRevenue, activeProducts, pendingRequests };
+  }
+}

--- a/src/admin/dto/create-hero-slide.dto.ts
+++ b/src/admin/dto/create-hero-slide.dto.ts
@@ -1,0 +1,31 @@
+import { IsBoolean, IsInt, IsOptional, IsString, IsUrl, Min } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class CreateHeroSlideDto {
+  @IsString()
+  title: string;
+
+  @IsString()
+  @IsOptional()
+  description?: string;
+
+  @IsUrl()
+  image: string;
+
+  @IsString()
+  @IsOptional()
+  buttonText?: string;
+
+  @IsString()
+  @IsOptional()
+  buttonLink?: string;
+
+  @IsBoolean()
+  @IsOptional()
+  isActive?: boolean;
+
+  @Type(() => Number)
+  @IsInt()
+  @Min(0)
+  order: number;
+}

--- a/src/admin/dto/create-promotion.dto.ts
+++ b/src/admin/dto/create-promotion.dto.ts
@@ -1,0 +1,27 @@
+import { IsBoolean, IsDateString, IsEnum, IsNumber, IsOptional, IsString } from 'class-validator';
+import { DiscountType } from '../promotion.entity';
+
+export class CreatePromotionDto {
+  @IsString()
+  name: string;
+
+  @IsString()
+  @IsOptional()
+  description?: string;
+
+  @IsEnum(['percent', 'fixed'])
+  discountType: DiscountType;
+
+  @IsNumber()
+  value: number;
+
+  @IsDateString()
+  startDate: string;
+
+  @IsDateString()
+  endDate: string;
+
+  @IsBoolean()
+  @IsOptional()
+  active?: boolean;
+}

--- a/src/admin/dto/update-hero-slide.dto.ts
+++ b/src/admin/dto/update-hero-slide.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateHeroSlideDto } from './create-hero-slide.dto';
+
+export class UpdateHeroSlideDto extends PartialType(CreateHeroSlideDto) {}

--- a/src/admin/dto/update-promotion.dto.ts
+++ b/src/admin/dto/update-promotion.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreatePromotionDto } from './create-promotion.dto';
+
+export class UpdatePromotionDto extends PartialType(CreatePromotionDto) {}

--- a/src/admin/hero-slide.entity.ts
+++ b/src/admin/hero-slide.entity.ts
@@ -1,0 +1,34 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn } from 'typeorm';
+
+@Entity()
+export class HeroSlide {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  title: string;
+
+  @Column({ nullable: true })
+  description?: string;
+
+  @Column()
+  image: string;
+
+  @Column({ nullable: true })
+  buttonText?: string;
+
+  @Column({ nullable: true })
+  buttonLink?: string;
+
+  @Column({ default: true })
+  isActive: boolean;
+
+  @Column('int')
+  order: number;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/admin/hero-slides.controller.ts
+++ b/src/admin/hero-slides.controller.ts
@@ -1,0 +1,39 @@
+import { Body, Controller, Delete, Get, Param, Post, Put, UseGuards } from '@nestjs/common';
+import { HeroSlidesService } from './hero-slides.service';
+import { CreateHeroSlideDto } from './dto/create-hero-slide.dto';
+import { UpdateHeroSlideDto } from './dto/update-hero-slide.dto';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { RolesGuard } from '../auth/roles.guard';
+import { Roles } from '../auth/roles.decorator';
+
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles('admin')
+@Controller('api/admin/hero-slides')
+export class HeroSlidesController {
+  constructor(private readonly heroSlidesService: HeroSlidesService) {}
+
+  @Get()
+  findAll() {
+    return this.heroSlidesService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.heroSlidesService.findOne(id);
+  }
+
+  @Post()
+  create(@Body() dto: CreateHeroSlideDto) {
+    return this.heroSlidesService.create(dto);
+  }
+
+  @Put(':id')
+  update(@Param('id') id: string, @Body() dto: UpdateHeroSlideDto) {
+    return this.heroSlidesService.update(id, dto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.heroSlidesService.remove(id);
+  }
+}

--- a/src/admin/hero-slides.service.ts
+++ b/src/admin/hero-slides.service.ts
@@ -1,0 +1,41 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { HeroSlide } from './hero-slide.entity';
+import { CreateHeroSlideDto } from './dto/create-hero-slide.dto';
+import { UpdateHeroSlideDto } from './dto/update-hero-slide.dto';
+
+@Injectable()
+export class HeroSlidesService {
+  constructor(
+    @InjectRepository(HeroSlide)
+    private slidesRepository: Repository<HeroSlide>,
+  ) {}
+
+  create(dto: CreateHeroSlideDto) {
+    const slide = this.slidesRepository.create(dto);
+    return this.slidesRepository.save(slide);
+  }
+
+  findAll() {
+    return this.slidesRepository.find();
+  }
+
+  async findOne(id: string) {
+    const slide = await this.slidesRepository.findOne({ where: { id } });
+    if (!slide) throw new NotFoundException('Slide not found');
+    return slide;
+  }
+
+  async update(id: string, dto: UpdateHeroSlideDto) {
+    const slide = await this.findOne(id);
+    Object.assign(slide, dto);
+    return this.slidesRepository.save(slide);
+  }
+
+  async remove(id: string) {
+    const slide = await this.findOne(id);
+    await this.slidesRepository.remove(slide);
+    return { message: 'Slide deleted' };
+  }
+}

--- a/src/admin/promotion.entity.ts
+++ b/src/admin/promotion.entity.ts
@@ -1,0 +1,36 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn } from 'typeorm';
+
+export type DiscountType = 'percent' | 'fixed';
+
+@Entity()
+export class Promotion {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  name: string;
+
+  @Column({ nullable: true })
+  description?: string;
+
+  @Column({ type: 'enum', enum: ['percent', 'fixed'] })
+  discountType: DiscountType;
+
+  @Column('float')
+  value: number;
+
+  @Column('date')
+  startDate: string;
+
+  @Column('date')
+  endDate: string;
+
+  @Column({ default: true })
+  active: boolean;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/admin/promotions.controller.ts
+++ b/src/admin/promotions.controller.ts
@@ -1,0 +1,39 @@
+import { Body, Controller, Delete, Get, Param, Post, Put, UseGuards } from '@nestjs/common';
+import { PromotionsService } from './promotions.service';
+import { CreatePromotionDto } from './dto/create-promotion.dto';
+import { UpdatePromotionDto } from './dto/update-promotion.dto';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { RolesGuard } from '../auth/roles.guard';
+import { Roles } from '../auth/roles.decorator';
+
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles('admin')
+@Controller('api/admin/promotions')
+export class PromotionsController {
+  constructor(private readonly promotionsService: PromotionsService) {}
+
+  @Get()
+  findAll() {
+    return this.promotionsService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.promotionsService.findOne(id);
+  }
+
+  @Post()
+  create(@Body() dto: CreatePromotionDto) {
+    return this.promotionsService.create(dto);
+  }
+
+  @Put(':id')
+  update(@Param('id') id: string, @Body() dto: UpdatePromotionDto) {
+    return this.promotionsService.update(id, dto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.promotionsService.remove(id);
+  }
+}

--- a/src/admin/promotions.service.ts
+++ b/src/admin/promotions.service.ts
@@ -1,0 +1,41 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Promotion } from './promotion.entity';
+import { CreatePromotionDto } from './dto/create-promotion.dto';
+import { UpdatePromotionDto } from './dto/update-promotion.dto';
+
+@Injectable()
+export class PromotionsService {
+  constructor(
+    @InjectRepository(Promotion)
+    private promotionsRepository: Repository<Promotion>,
+  ) {}
+
+  create(dto: CreatePromotionDto) {
+    const promo = this.promotionsRepository.create(dto);
+    return this.promotionsRepository.save(promo);
+  }
+
+  findAll() {
+    return this.promotionsRepository.find();
+  }
+
+  async findOne(id: string) {
+    const promo = await this.promotionsRepository.findOne({ where: { id } });
+    if (!promo) throw new NotFoundException('Promotion not found');
+    return promo;
+  }
+
+  async update(id: string, dto: UpdatePromotionDto) {
+    const promo = await this.findOne(id);
+    Object.assign(promo, dto);
+    return this.promotionsRepository.save(promo);
+  }
+
+  async remove(id: string) {
+    const promo = await this.findOne(id);
+    await this.promotionsRepository.remove(promo);
+    return { message: 'Promotion deleted' };
+  }
+}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -15,6 +15,9 @@ import { ProfileModule } from './profile/profile.module';
 import { SearchModule } from './search/search.module';
 import { ProfessionalRequest } from './professional/professional-request.entity';
 import { ProfessionalModule } from './professional/professional.module';
+import { AdminModule } from './admin/admin.module';
+import { HeroSlide } from './admin/hero-slide.entity';
+import { Promotion } from './admin/promotion.entity';
 
 @Module({
   imports: [
@@ -22,7 +25,16 @@ import { ProfessionalModule } from './professional/professional.module';
     TypeOrmModule.forRoot({
       type: 'postgres',
       url: process.env.DATABASE_URL,
-      entities: [User, Category, Product, Service, Order, ProfessionalRequest],
+      entities: [
+        User,
+        Category,
+        Product,
+        Service,
+        Order,
+        ProfessionalRequest,
+        HeroSlide,
+        Promotion,
+      ],
       synchronize: true,
     }),
     AuthModule,
@@ -33,6 +45,7 @@ import { ProfessionalModule } from './professional/professional.module';
     ProfileModule,
     SearchModule,
     ProfessionalModule,
+    AdminModule,
   ],
 })
 export class AppModule {}

--- a/test/admin.e2e-spec.ts
+++ b/test/admin.e2e-spec.ts
@@ -1,0 +1,118 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { AppModule } from '../src/app.module';
+import { UsersService } from '../src/users/users.service';
+
+describe('AdminModule (e2e)', () => {
+  let app: INestApplication;
+  let adminToken: string;
+  let userToken: string;
+  let usersService: UsersService;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    usersService = moduleFixture.get(UsersService);
+    await app.init();
+  });
+
+  it('setup users', async () => {
+    const email = 'adminhs@example.com';
+    const user = await usersService.create({ email, password: 'pass' } as any);
+    user.role = 'admin';
+    await usersService['usersRepository'].save(user);
+    const res = await request(app.getHttpServer())
+      .post('/auth/login')
+      .send({ email, password: 'pass' })
+      .expect(201);
+    adminToken = res.body.access_token;
+
+    const userEmail = 'user@example.com';
+    await usersService.create({ email: userEmail, password: 'pass' } as any);
+    const res2 = await request(app.getHttpServer())
+      .post('/auth/login')
+      .send({ email: userEmail, password: 'pass' })
+      .expect(201);
+    userToken = res2.body.access_token;
+  });
+
+  it('hero slides CRUD', async () => {
+    const createRes = await request(app.getHttpServer())
+      .post('/api/admin/hero-slides')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ title: 'Slide', image: 'http://example.com/img.jpg', order: 1 })
+      .expect(201);
+    const id = createRes.body.id;
+
+    await request(app.getHttpServer())
+      .get('/api/admin/hero-slides')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .expect(200);
+
+    await request(app.getHttpServer())
+      .get(`/api/admin/hero-slides/${id}`)
+      .set('Authorization', `Bearer ${adminToken}`)
+      .expect(200);
+
+    await request(app.getHttpServer())
+      .put(`/api/admin/hero-slides/${id}`)
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ title: 'Updated' })
+      .expect(200);
+
+    await request(app.getHttpServer())
+      .delete(`/api/admin/hero-slides/${id}`)
+      .set('Authorization', `Bearer ${adminToken}`)
+      .expect(200);
+
+    await request(app.getHttpServer())
+      .get(`/api/admin/hero-slides/${id}`)
+      .set('Authorization', `Bearer ${adminToken}`)
+      .expect(404);
+  });
+
+  it('promotions CRUD', async () => {
+    const createRes = await request(app.getHttpServer())
+      .post('/api/admin/promotions')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({
+        name: 'Promo',
+        discountType: 'percent',
+        value: 10,
+        startDate: '2024-01-01',
+        endDate: '2024-12-31',
+      })
+      .expect(201);
+    const id = createRes.body.id;
+    await request(app.getHttpServer())
+      .get('/api/admin/promotions')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .expect(200);
+    await request(app.getHttpServer())
+      .put(`/api/admin/promotions/${id}`)
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ active: false })
+      .expect(200);
+    await request(app.getHttpServer())
+      .delete(`/api/admin/promotions/${id}`)
+      .set('Authorization', `Bearer ${adminToken}`)
+      .expect(200);
+  });
+
+  it('forbidden for non admin', async () => {
+    await request(app.getHttpServer())
+      .get('/api/admin/hero-slides')
+      .set('Authorization', `Bearer ${userToken}`)
+      .expect(403);
+  });
+
+  it('unauthorized', async () => {
+    await request(app.getHttpServer())
+      .get('/api/admin/hero-slides')
+      .expect(401);
+  });
+});


### PR DESCRIPTION
## Summary
- add `admin` module featuring hero slides, promotions and admin dashboard
- register new entities and module in `AppModule`
- provide guarded controllers for hero slides and promotions
- add tests covering admin endpoints

## Testing
- `npx jest --runInBand` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*

------
https://chatgpt.com/codex/tasks/task_e_685d65c02e14832c917ffe4c8f59ee52